### PR TITLE
fix type passed to memset() on print_watchers

### DIFF
--- a/common/common_main.c
+++ b/common/common_main.c
@@ -246,7 +246,7 @@ int main(int argc, char *const *argv) {
 	memset(&sigterm_watcher, 0, sizeof(ev_signal));
 	memset(&sigbreak_watcher, 0, sizeof(ev_signal));
 #ifdef UTIL_DEBUG
-	memset(&print_watchers, 0, sizeof(ev_signal));
+	memset(&print_watchers, 0, sizeof(ev_check));
 #endif // UTIL_DEBUG
 #ifdef _WIN32
 	WORD w_version_requested;


### PR DESCRIPTION
print_watchers is of type ev_check, as declared in the same file starting line 42:

    #ifdef UTIL_DEBUG
    ev_check print_watchers;
    #endif // UTIL_DEBUG